### PR TITLE
Colored hue slider

### DIFF
--- a/harbour-tint.pro
+++ b/harbour-tint.pro
@@ -43,7 +43,8 @@ CONFIG += sailfishapp_i18n
 # planning to localize your app, remember to comment out the
 # following TRANSLATIONS line. And also do not forget to
 # modify the localized app name in the the .desktop file.
-TRANSLATIONS += translations/harbour-tint-fr.ts
+TRANSLATIONS += translations/harbour-tint-fr.ts \
+    translations/harbour-tint-fi.ts
 
 HEADERS += \
     huediscovery.h

--- a/harbour-tint.pro
+++ b/harbour-tint.pro
@@ -30,7 +30,8 @@ DISTFILES += qml/harbour-tint.qml \
     qml/pages/NewLightsPage.qml \
     qml/pages/EditGroupDialog.qml \
     qml/pages/BridgePropertiesPage.qml \
-    qml/pages/InputDialog.qml
+    qml/pages/InputDialog.qml \
+    qml/pages/ColorSlider.qml
 
 SAILFISHAPP_ICONS = 86x86 108x108 128x128 172x172
 

--- a/qml/pages/BridgePage.qml
+++ b/qml/pages/BridgePage.qml
@@ -247,6 +247,7 @@ Page {
                         width: parent.width
                         handleVisible: true
                         stepSize: 1
+                        anchors.verticalCenter: parent.verticalCenter
                         value: room.action.hue
                         onEvent: {
                             bridge.setGroupState(room_id, {hue: value},

--- a/qml/pages/BridgePage.qml
+++ b/qml/pages/BridgePage.qml
@@ -240,7 +240,7 @@ Page {
 //                        text: qsTr("Hue")
 //                        anchors.verticalCenter: parent.verticalCenter
 //                    }
-                    PacedSlider {
+                    ColorSlider {
                         id: hue_slider
                         minimumValue: 0
                         maximumValue: 65535

--- a/qml/pages/ColorSlider.qml
+++ b/qml/pages/ColorSlider.qml
@@ -26,8 +26,6 @@ MouseArea {
     property bool _widthChanged
     property bool _cancel
 
-    property bool _componentComplete
-
     property int synced_value: value
     property int pace: 500
 
@@ -267,7 +265,7 @@ MouseArea {
 
     states: State {
         name: "invalidRange"
-        when: _componentComplete && minimumValue >= maximumValue
+        when: completed && minimumValue >= maximumValue
         PropertyChanges {
             target: slider
             enabled: false
@@ -280,7 +278,6 @@ MouseArea {
 
     Component.onCompleted: {
         completed = true
-        _componentComplete = true
         _updateHighlightToValue()
     }
 }

--- a/qml/pages/ColorSlider.qml
+++ b/qml/pages/ColorSlider.qml
@@ -15,8 +15,8 @@ MouseArea {
     property alias label: labelText.text
     property bool down: pressed
     property bool highlighted: down
-    property real leftMargin: Math.round(Screen.width/8)
-    property real rightMargin: Math.round(Screen.width/8)
+    property real leftMargin: Math.round(Screen.width/6.8)
+    property real rightMargin: Math.round(Screen.width/6.8)
 
     property real _oldValue
     property bool _tracking: true

--- a/qml/pages/ColorSlider.qml
+++ b/qml/pages/ColorSlider.qml
@@ -1,0 +1,286 @@
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+
+MouseArea {
+    id: slider
+
+    property real maximumValue: 1.0
+    property real minimumValue: 0.0
+    property real stepSize
+    property alias lightness: rainbow.lightness
+    property alias saturation: rainbow.saturation
+    property alias alpha: rainbow.alpha
+    readonly property real sliderValue: Math.max(minimumValue, Math.min(maximumValue, value))
+    property bool handleVisible: true
+    property alias label: labelText.text
+    property bool down: pressed
+    property bool highlighted: down
+    property real leftMargin: Math.round(Screen.width/8)
+    property real rightMargin: Math.round(Screen.width/8)
+
+    property real _oldValue
+    property bool _tracking: true
+    property real _precFactor: 1.0
+
+    property real _grooveWidth: Math.max(0, width - leftMargin - rightMargin)
+    property bool _widthChanged
+    property bool _cancel
+
+    property bool _componentComplete
+
+    property int synced_value: value
+    property int pace: 500
+
+    property bool completed: false
+
+    property real value
+
+    signal event
+
+    Timer {
+        id: pacer
+        interval: pace; running: false; repeat: true
+        onTriggered: { if (parent.value == parent.synced_value) {
+                           pacer.stop()
+                        }
+                        else {
+                            parent.sync()
+                        }
+                      }
+    }
+
+    function sync() {
+        synced_value = value;
+        event()
+    }
+
+    onValueChanged: {
+        if (!pacer.running && completed) {
+            console.log("Value changed")
+            pacer.start()
+            sync()
+        }
+    }
+
+    onStepSizeChanged: {
+        // Avoid rounding errors.  We assume that the range will
+        // be sensibly related to stepSize
+        var decimial = Math.floor(stepSize) - stepSize
+        if (decimial < 0.001) {
+            _precFactor = Math.pow(10, 7)
+        } else if (decimial < 0.1) {
+            _precFactor = Math.pow(10, 4)
+        } else {
+            _precFactor = 1.0
+        }
+    }
+
+    height: handleVisible ? Theme.itemSizeExtraLarge : label !== "" ? Theme.itemSizeMedium : Theme.itemSizeSmall
+
+    onWidthChanged: updateWidth()
+    onLeftMarginChanged: updateWidth()
+    onRightMarginChanged: updateWidth()
+
+    // changing the width of the slider shouldn't animate the slider bar/handle
+    function updateWidth() {
+        _widthChanged = true
+        _grooveWidth = Math.max(0, width - leftMargin - rightMargin)
+        _widthChanged = false
+    }
+
+    drag {
+        target: draggable
+        minimumX: leftMargin - highlight.width/2
+        maximumX: slider.width - leftMargin - highlight.width/2
+        axis: Drag.XAxis
+    }
+
+    function _updateHighlightToValue() {
+        if (maximumValue > minimumValue) {
+            highlight.x = (sliderValue - minimumValue) / (maximumValue - minimumValue) * _grooveWidth - highlight.width/2 + leftMargin
+        } else {
+            highlight.x = leftMargin - highlight.width/2
+        }
+    }
+
+    function _updateValueToDraggable() {
+        if (width > (leftMargin + rightMargin)) {
+            highlight.x = draggable.x
+            var pos = draggable.x + highlight.width/2 - leftMargin
+            value = _calcValue((pos / _grooveWidth) * (maximumValue - minimumValue) + minimumValue)
+        }
+    }
+
+    function _calcValue(newVal) {
+        if (newVal <= minimumValue) {
+            return minimumValue
+        }
+
+        if (stepSize > 0.0) {
+            var offset = newVal - minimumValue
+            var intervals = Math.round(offset / stepSize)
+            newVal = Math.round((minimumValue + (intervals * stepSize)) * _precFactor) / _precFactor
+        }
+
+        if (newVal > maximumValue) {
+            return maximumValue
+        }
+
+        return newVal
+    }
+
+    onPressed: {
+        _cancel = false
+        _oldValue = value
+        draggable.x = Math.min(Math.max(drag.minimumX, mouseX - highlight.width/2), drag.maximumX)
+    }
+
+    onReleased: {
+        if (!_cancel) {
+            _tracking = false
+            _updateValueToDraggable()
+            if (stepSize != 0.0) {
+                // on release make sure that we settle on a step boundary
+                _updateHighlightToValue()
+            }
+            _oldValue = value
+        }
+    }
+
+    onSliderValueChanged: {
+        if (!slider.drag.active) {
+            _tracking = false
+            _updateHighlightToValue()
+        }
+    }
+
+    Rectangle {
+        id: background
+        x: slider.leftMargin-Theme.paddingMedium
+        width: slider._grooveWidth + 2*Theme.paddingMedium
+        height: Theme.paddingMedium
+        onWidthChanged: { _tracking = true; _updateHighlightToValue() }
+        anchors.top: parent.verticalCenter
+
+        ShaderEffect {
+            id: rainbow
+            property variant src: background
+            property real saturation: 1.0
+            property real lightness: 0.5
+            property real alpha: 1.0
+
+            width: parent.width
+            height: parent.height
+
+            // Fragment shader to create hue color wheel background
+            fragmentShader: "
+                varying highp vec2 coord;
+                varying highp vec2 qt_TexCoord0;
+                uniform sampler2D src;
+                uniform lowp float qt_Opacity;
+                uniform lowp float saturation;
+                uniform lowp float lightness;
+                uniform lowp float alpha;
+
+                void main() {
+                    lowp float r, g, b;
+
+                    highp float h = qt_TexCoord0.x * 360.0;
+                    lowp float s = saturation;
+                    lowp float l = lightness;
+
+                    lowp float c = (1.0 - abs(2.0 * l - 1.0)) * s;
+                    highp float hh = h / 60.0;
+                    lowp float x = c * (1.0 - abs(mod(hh, 2.0) - 1.0));
+
+                    int i = int( hh );
+
+                    if (i == 0) {
+                        r = c; g = x; b = 0.0;
+                    } else if (i == 1) {
+                        r = x; g = c; b = 0.0;
+                    } else if (i == 2) {
+                        r = 0.0; g = c; b = x;
+                    } else if (i == 3) {
+                        r = 0.0; g = x; b = c;
+                    } else if (i == 4) {
+                        r = x; g = 0.0; b = c;
+                    } else if (i == 5) {
+                        r = c; g = 0.0; b = x;
+                    } else {
+                        r = 0.0; g = 0.0; b = 0.0;
+                    }
+
+                    lowp float m = l - 0.5 * c;
+
+                    lowp vec4 tex = texture2D(src, qt_TexCoord0);
+                    gl_FragColor = vec4(r+m,g+m,b+m,alpha) * qt_Opacity;
+                }"
+        }
+    }
+
+    Item {
+        id: draggable
+        width: highlight.width
+        height: highlight.height
+        onXChanged: {
+            if (_cancel) {
+                return
+            }
+            if (slider.drag.active) {
+                _updateValueToDraggable()
+            }
+            if (!_tracking && Math.abs(highlight.x - draggable.x) < 5) {
+                _tracking = true
+            }
+        }
+    }
+
+    GlassItem {
+        id: highlight
+        width: Theme.itemSizeMedium
+        height: Theme.itemSizeMedium
+        radius: 0.17
+        falloffRadius: 0.17
+        anchors {
+            verticalCenter: background.verticalCenter
+        }
+        visible: handleVisible
+        color: slider.highlighted ? palette.highlightColor : Theme.lightPrimaryColor
+        Behavior on x {
+            enabled: !_widthChanged
+            SmoothedAnimation { velocity: 1500 }
+        }
+    }
+
+    Label {
+        id: labelText
+        visible: text.length
+        font.pixelSize: Theme.fontSizeSmall
+        color: slider.highlighted ? palette.highlightColor : palette.secondaryColor
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: background.verticalCenter
+        anchors.topMargin: Theme.paddingMedium
+        width: Math.min(paintedWidth, parent.width - 2*Theme.paddingMedium)
+        truncationMode: TruncationMode.Fade
+    }
+
+    states: State {
+        name: "invalidRange"
+        when: _componentComplete && minimumValue >= maximumValue
+        PropertyChanges {
+            target: slider
+            enabled: false
+            opacity: 0.6
+        }
+        StateChangeScript {
+            script: console.log("Warning: Slider.maximumValue needs to be higher than Slider.minimumValue")
+        }
+    }
+
+    Component.onCompleted: {
+        completed = true
+        _componentComplete = true
+        _updateHighlightToValue()
+    }
+}

--- a/translations/harbour-tint-fi.ts
+++ b/translations/harbour-tint-fi.ts
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>BridgePage</name>
+    <message>
+        <source>Rooms</source>
+        <translation>Huoneet</translation>
+    </message>
+    <message>
+        <source>Lights</source>
+        <translation>Valaisimet</translation>
+    </message>
+    <message>
+        <source>New group</source>
+        <translation>Uusi ryhmä</translation>
+    </message>
+    <message>
+        <source>Bridge properties</source>
+        <translation>Sillan tiedot</translation>
+    </message>
+    <message>
+        <source>Global</source>
+        <translation>Kaikki</translation>
+    </message>
+    <message>
+        <source>Edit group</source>
+        <translation>Muokkaa ryhmää</translation>
+    </message>
+    <message>
+        <source>Rename group</source>
+        <translation>Uudelleennimeä ryhmä</translation>
+    </message>
+    <message>
+        <source>Delete group</source>
+        <translation>Poista ryhmä</translation>
+    </message>
+    <message>
+        <source>Deleting group</source>
+        <translation>Poistetaan ryhmää</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Nimi</translation>
+    </message>
+</context>
+<context>
+    <name>BridgePropertiesPage</name>
+    <message>
+        <source>Install updates</source>
+        <translation>Asenna päivitykset</translation>
+    </message>
+    <message>
+        <source>Check for updates</source>
+        <translation>Tarkista päivitykset</translation>
+    </message>
+    <message>
+        <source>Installing updates</source>
+        <translation>Asennetaan päivityksiä</translation>
+    </message>
+    <message>
+        <source>No updates available</source>
+        <translation>Ei päivityksiä saatavilla</translation>
+    </message>
+    <message>
+        <source>Transferring</source>
+        <translation>Siirretään</translation>
+    </message>
+    <message>
+        <source>All ready to install</source>
+        <translation>Kaikki asennettavissa</translation>
+    </message>
+    <message>
+        <source>Some ready to install</source>
+        <translation>Joitain asennettavissa</translation>
+    </message>
+    <message>
+        <source>Installing</source>
+        <translation>Asennetaan</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation>Tuntematon</translation>
+    </message>
+    <message>
+        <source>Bridge properties</source>
+        <translation>Sillan tiedot</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Nimi</translation>
+    </message>
+    <message>
+        <source>Model</source>
+        <translation>Malli</translation>
+    </message>
+    <message>
+        <source>Updates</source>
+        <translation>Päivitykset</translation>
+    </message>
+    <message>
+        <source>Software version</source>
+        <translation>Ohjelmistoversio</translation>
+    </message>
+    <message>
+        <source>IP address</source>
+        <translation>IP-osoite</translation>
+    </message>
+    <message>
+        <source>MAC address</source>
+        <translation>MAC-osoite</translation>
+    </message>
+    <message>
+        <source>Bridge id</source>
+        <translation>Sillan tunniste</translation>
+    </message>
+</context>
+<context>
+    <name>CoverPage</name>
+    <message>
+        <source>Tint</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FirstPage</name>
+    <message>
+        <source>Available bridges</source>
+        <translation>Saatavilla olevat sillat</translation>
+    </message>
+    <message>
+        <source>No bridges found</source>
+        <translation>Siltoja ei löytynyt</translation>
+    </message>
+    <message>
+        <source>Unpair</source>
+        <translation>Pura liitos</translation>
+    </message>
+    <message>
+        <source>Bridge</source>
+        <translation>Silta</translation>
+    </message>
+    <message>
+        <source>Refresh</source>
+        <translation>Virkistä</translation>
+    </message>
+    <message>
+        <source>Unpairing bridge</source>
+        <translation>Puretaan sillan pariliitosta</translation>
+    </message>
+</context>
+<context>
+    <name>LightsPage</name>
+    <message>
+        <source>Lights</source>
+        <translation>Valaisimet</translation>
+    </message>
+    <message>
+        <source>New Lights</source>
+        <translation>Lisää valaisin</translation>
+    </message>
+    <message>
+        <source>Rename light</source>
+        <translation>Uudelleennimeä valaisin</translation>
+    </message>
+    <message>
+        <source>Delete light</source>
+        <translation>Poista valaisin</translation>
+    </message>
+    <message>
+        <source>Deleting light</source>
+        <translation>Poistetaan valaisinta</translation>
+    </message>
+</context>
+<context>
+    <name>NewLightsPage</name>
+    <message>
+        <source>New Lights</source>
+        <translation>Valaisinten lisäys</translation>
+    </message>
+    <message>
+        <source>Search again</source>
+        <translation>Etsi uudelleen</translation>
+    </message>
+    <message>
+        <source>Enable TouchLink</source>
+        <translation>Ota TouchLink käyttöön</translation>
+    </message>
+    <message>
+        <source>Search by ID</source>
+        <translation>Etsi sarjanumerolla</translation>
+    </message>
+    <message>
+        <source>ID</source>
+        <translation>Sarjanumero</translation>
+    </message>
+</context>
+<context>
+    <name>PairDialog</name>
+    <message>
+        <source>Pairing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Press the pairing button</source>
+        <translation>Paina pariliitosnappia</translation>
+    </message>
+    <message>
+        <source>Success!</source>
+        <translation>Onnistui!</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Added visual color clue to the hue slider so that the user does not need to select color blindly.

Changes introduced in this PR are purely cosmetic. The underlying functionality remains the same. It is a lot of code since I couldn't inherit Slider. The ColorSlider code is adapted from `/usr/lib/qt5/qml/com/jolla/gallery/ambience/ColorSlider.qml` with modifications.